### PR TITLE
VW MQB: use ECD to enable Stop & Go for MQB platform manual vehicles with ACC Low

### DIFF
--- a/cereal/custom.capnp
+++ b/cereal/custom.capnp
@@ -207,6 +207,11 @@ struct LongitudinalPlanSP @0xf35cc4560bbf6ec2 {
       distToSpeedLimit @1 :Float32;
       source @2 :Source;
       speedLimitOffset @3 :Float32;
+      speedLimitLast @4 :Float32;
+      speedLimitFinal @5 :Float32;
+      speedLimitFinalLast @6 :Float32;
+      speedLimitValid @7 :Bool;
+      speedLimitLastValid @8 :Bool;
     }
 
     enum Source {

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/longitudinal_panel.cc
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/longitudinal_panel.cc
@@ -102,7 +102,6 @@ void LongitudinalPanel::showEvent(QShowEvent *event) {
 }
 
 void LongitudinalPanel::refresh(bool _offroad) {
-  auto icbm_available = false;
   auto cp_bytes = params.get("CarParamsPersistent");
   auto cp_sp_bytes = params.get("CarParamsSPPersistent");
   if (!cp_bytes.empty() && !cp_sp_bytes.empty()) {
@@ -115,12 +114,11 @@ void LongitudinalPanel::refresh(bool _offroad) {
 
     has_longitudinal_control = hasLongitudinalControl(CP);
     is_pcm_cruise = CP.getPcmCruise();
-    icbm_available = CP_SP.getIntelligentCruiseButtonManagementAvailable();
-    has_intelligent_cruise_button_management = hasIntelligentCruiseButtonManagement(CP_SP);
+    intelligent_cruise_button_management_available = CP_SP.getIntelligentCruiseButtonManagementAvailable();
   } else {
     has_longitudinal_control = false;
     is_pcm_cruise = false;
-    has_intelligent_cruise_button_management = false;
+    intelligent_cruise_button_management_available = false;
   }
 
   QString accEnabledDescription = tr("Enable custom Short & Long press increments for cruise speed increase/decrease.");
@@ -132,7 +130,7 @@ void LongitudinalPanel::refresh(bool _offroad) {
     customAccIncrement->setDescription(onroadOnlyDescription);
     customAccIncrement->showDescription();
   } else {
-    if (has_longitudinal_control || icbm_available) {
+    if (has_longitudinal_control || intelligent_cruise_button_management_available) {
       if (is_pcm_cruise) {
         customAccIncrement->setDescription(accPcmCruiseDisabledDescription);
         customAccIncrement->showDescription();
@@ -149,7 +147,7 @@ void LongitudinalPanel::refresh(bool _offroad) {
     }
   }
 
-  bool icbm_allowed = has_intelligent_cruise_button_management && !has_longitudinal_control;
+  bool icbm_allowed = intelligent_cruise_button_management_available && !has_longitudinal_control;
   intelligentCruiseButtonManagement->setEnabled(icbm_allowed && offroad);
 
   // enable toggle when long is available and is not PCM cruise

--- a/selfdrive/ui/sunnypilot/qt/offroad/settings/longitudinal_panel.h
+++ b/selfdrive/ui/sunnypilot/qt/offroad/settings/longitudinal_panel.h
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include "selfdrive/ui/sunnypilot/qt/util.h"
 #include "selfdrive/ui/sunnypilot/qt/offroad/settings/longitudinal/custom_acc_increment.h"
 #include "selfdrive/ui/sunnypilot/qt/offroad/settings/longitudinal/speed_limit/speed_limit_settings.h"
 #include "selfdrive/ui/sunnypilot/qt/offroad/settings/settings.h"
@@ -25,7 +24,7 @@ private:
   Params params;
   bool has_longitudinal_control = false;
   bool is_pcm_cruise = false;
-  bool has_intelligent_cruise_button_management = false;;
+  bool intelligent_cruise_button_management_available = false;;
   bool offroad = false;
 
   ParamControl *eEPBopLongToggle;

--- a/selfdrive/ui/sunnypilot/qt/onroad/hud.cc
+++ b/selfdrive/ui/sunnypilot/qt/onroad/hud.cc
@@ -34,7 +34,7 @@ void HudRendererSP::updateState(const UIState &s) {
   speedLimitOffset = lp_sp.getSpeedLimit().getResolver().getSpeedLimitOffset() * speedConv;
   speedLimitValid = lp_sp.getSpeedLimit().getResolver().getSpeedLimitValid();
   speedLimitLastValid = lp_sp.getSpeedLimit().getResolver().getSpeedLimitLastValid();
-  speedLimitFinalLast = lp_sp.getSpeedLimit().getResolver().getSpeedLimitFinalLast();
+  speedLimitFinalLast = lp_sp.getSpeedLimit().getResolver().getSpeedLimitFinalLast() * speedConv;
   speedLimitMode = static_cast<SpeedLimitMode>(s.scene.speed_limit_mode);
   roadName = s.scene.road_name;
   if (sm.updated("liveMapDataSP")) {

--- a/selfdrive/ui/sunnypilot/qt/onroad/hud.cc
+++ b/selfdrive/ui/sunnypilot/qt/onroad/hud.cc
@@ -30,9 +30,11 @@ void HudRendererSP::updateState(const UIState &s) {
 
   float speedConv = is_metric ? MS_TO_KPH : MS_TO_MPH;
   speedLimit = lp_sp.getSpeedLimit().getResolver().getSpeedLimit() * speedConv;
+  speedLimitLast = lp_sp.getSpeedLimit().getResolver().getSpeedLimitLast() * speedConv;
   speedLimitOffset = lp_sp.getSpeedLimit().getResolver().getSpeedLimitOffset() * speedConv;
-  speedLimitValid = speedLimit > 0;
-  speedLimitLastValid = speedLimitLast > 0;
+  speedLimitValid = lp_sp.getSpeedLimit().getResolver().getSpeedLimitValid();
+  speedLimitLastValid = lp_sp.getSpeedLimit().getResolver().getSpeedLimitLastValid();
+  speedLimitFinalLast = lp_sp.getSpeedLimit().getResolver().getSpeedLimitFinalLast();
   speedLimitMode = static_cast<SpeedLimitMode>(s.scene.speed_limit_mode);
   roadName = s.scene.road_name;
   if (sm.updated("liveMapDataSP")) {
@@ -47,10 +49,6 @@ void HudRendererSP::updateState(const UIState &s) {
     }
   }
   speedLimitAheadDistancePrev = speedLimitAheadDistance;
-
-  if (speedLimitValid) {
-    speedLimitLast = speedLimit;
-  }
 
   static int reverse_delay = 0;
   bool reverse_allowed = false;
@@ -351,12 +349,10 @@ void HudRendererSP::drawStandstillTimer(QPainter &p, int x, int y) {
 }
 
 void HudRendererSP::drawSpeedLimitSigns(QPainter &p) {
-  bool hasSpeedLimit = speedLimitValid || speedLimitLastValid;
-  int speedLimitFinal = std::nearbyint(speedLimitValid ? speedLimit : speedLimitLast);
-  int speedLimitOffsetFinal = speedLimitFinal + std::nearbyint(speedLimitOffset);
-  bool overspeed = hasSpeedLimit && speedLimitOffsetFinal < std::nearbyint(speed);
   bool speedLimitWarningEnabled = speedLimitMode == SpeedLimitMode::WARNING;  // TODO-SP: update to include SpeedLimitMode::ASSIST
-  QString speedLimitStr = hasSpeedLimit ? QString::number(speedLimitFinal) : "---";
+  bool hasSpeedLimit = speedLimitValid || speedLimitLastValid;
+  bool overspeed = hasSpeedLimit && speedLimitFinalLast < std::nearbyint(speed);
+  QString speedLimitStr = hasSpeedLimit ? QString::number(std::nearbyint(speedLimitLast)) : "---";
 
   // Offset display text
   QString speedLimitSubText = "";

--- a/selfdrive/ui/sunnypilot/qt/onroad/hud.h
+++ b/selfdrive/ui/sunnypilot/qt/onroad/hud.h
@@ -77,6 +77,7 @@ private:
   float speedLimitOffset;
   bool speedLimitValid;
   bool speedLimitLastValid;
+  float speedLimitFinalLast;
   bool speedLimitAheadValid;
   float speedLimitAhead;
   float speedLimitAheadDistance;

--- a/selfdrive/ui/sunnypilot/qt/util.cc
+++ b/selfdrive/ui/sunnypilot/qt/util.cc
@@ -123,7 +123,3 @@ std::optional<cereal::Event::Reader> loadCerealEvent(Params& params, const std::
     return std::nullopt;
   }
 }
-
-bool hasIntelligentCruiseButtonManagement(const cereal::CarParamsSP::Reader &car_params_sp) {
-  return car_params_sp.getIntelligentCruiseButtonManagementAvailable() && Params().getBool("IntelligentCruiseButtonManagement");
-}

--- a/selfdrive/ui/sunnypilot/qt/util.h
+++ b/selfdrive/ui/sunnypilot/qt/util.h
@@ -23,4 +23,3 @@ std::optional<QString> getParamIgnoringDefault(const std::string &param_name, co
 QMap<QString, QVariantMap> loadPlatformList();
 QStringList searchFromList(const QString &query, const QStringList &list);
 std::optional<cereal::Event::Reader> loadCerealEvent(Params& params, const std::string& _param);
-bool hasIntelligentCruiseButtonManagement(const cereal::CarParamsSP::Reader &car_params_sp);

--- a/sunnypilot/selfdrive/controls/lib/longitudinal_planner.py
+++ b/sunnypilot/selfdrive/controls/lib/longitudinal_planner.py
@@ -96,6 +96,11 @@ class LongitudinalPlannerSP:
     speedLimit = longitudinalPlanSP.speedLimit
     resolver = speedLimit.resolver
     resolver.speedLimit = float(self.resolver.speed_limit)
+    resolver.speedLimitLast = float(self.resolver.speed_limit_last)
+    resolver.speedLimitFinal = float(self.resolver.speed_limit_final)
+    resolver.speedLimitFinalLast = float(self.resolver.speed_limit_final_last)
+    resolver.speedLimitValid = self.resolver.speed_limit_valid
+    resolver.speedLimitLastValid = self.resolver.speed_limit_last_valid
     resolver.speedLimitOffset = float(self.resolver.speed_limit_offset)
     resolver.distToSpeedLimit = float(self.resolver.distance)
     resolver.source = self.resolver.source

--- a/sunnypilot/selfdrive/controls/lib/smart_cruise_control/map_controller.py
+++ b/sunnypilot/selfdrive/controls/lib/smart_cruise_control/map_controller.py
@@ -12,8 +12,8 @@ from openpilot.sunnypilot.selfdrive.controls.lib.smart_cruise_control import MIN
 
 MapState = VisionState = custom.LongitudinalPlanSP.SmartCruiseControl.MapState
 
-ACTIVE_STATES = (MapState.turning, MapState.overriding)
-ENABLED_STATES = (MapState.enabled, *ACTIVE_STATES)
+ACTIVE_STATES = (MapState.turning, )
+ENABLED_STATES = (MapState.enabled, MapState.overriding, *ACTIVE_STATES)
 
 R = 6373000.0  # approximate radius of earth in meters
 TO_RADIANS = math.pi / 180

--- a/sunnypilot/selfdrive/controls/lib/speed_limit/speed_limit_resolver.py
+++ b/sunnypilot/selfdrive/controls/lib/speed_limit/speed_limit_resolver.py
@@ -26,6 +26,9 @@ class SpeedLimitResolver:
   distance_solutions: dict[custom.LongitudinalPlanSP.SpeedLimit.Source, float]
   v_ego: float
   speed_limit: float
+  speed_limit_last: float
+  speed_limit_final: float
+  speed_limit_final_last: float
   distance: float
   source: custom.LongitudinalPlanSP.SpeedLimit.Source
   speed_limit_offset: float
@@ -53,6 +56,21 @@ class SpeedLimitResolver:
     self.is_metric = self.params.get_bool("IsMetric")
     self.offset_type = self.params.get("SpeedLimitOffsetType", return_default=True)
     self.offset_value = self.params.get("SpeedLimitValueOffset", return_default=True)
+
+  def update_speed_limit_states(self) -> None:
+    self.speed_limit_final = self.speed_limit + self.speed_limit_offset
+
+    if self.speed_limit > 0.:
+      self.speed_limit_last = self.speed_limit
+      self.speed_limit_final_last = self.speed_limit_final
+
+  @property
+  def speed_limit_valid(self) -> bool:
+    return self.speed_limit > 0.
+
+  @property
+  def speed_limit_last_valid(self) -> bool:
+    return self.speed_limit_last > 0.
 
   def update_params(self):
     if self.frame % int(PARAMS_UPDATE_PERIOD / DT_MDL) == 0:
@@ -148,5 +166,7 @@ class SpeedLimitResolver:
 
     self.speed_limit, self.distance, self.source = self._resolve_limit_sources(sm)
     self.speed_limit_offset = self._get_speed_limit_offset()
+
+    self.update_speed_limit_states()
 
     self.frame += 1


### PR DESCRIPTION
checklist:
- define EPB_01
- find ECD signals
- add EPB to mqbcan & packer
- add EPB_01 CRC identifier to mqbcan & panda safety
- add to carcontroller
- parse response from carstate
- test
- add to safety test
- add safety limitation of max -3.5 m/s^2 decel for "ACC (opLong)" & max -8 m/s^2 decel for AEB usage
- potentially map & filter for OP AEB & filter off real EPB on vehicles with EPB when OP AEB triggers, this has not been decided yet. 

this PR also brings the -kombi branch up to date, but the #2 does that & will be merged before this one.

do NOT merge this PR without merging [this PR](https://github.com/tealtwo/opendbc/pull/3)